### PR TITLE
feat: Add pagination for github repositories

### DIFF
--- a/src/utils/api/Bitbucket.js
+++ b/src/utils/api/Bitbucket.js
@@ -33,20 +33,22 @@ export default class Bitbucket {
    *
    * @param {String} team The name of the team.
    */
-  repositories({ team, perPage = 100, params = [] } = {}) {
+  repositories({ team, params = {} } = {}) {
     const url = team ? `/repositories/${team}` : "/repositories";
 
     return new Promise((resolve, reject) => {
       const headers = prepareHeaders(this.accessToken);
 
       // push default params if no params set yet
-      if (params.length === 0) {
-        params.push({ name: "role", value: "admin" });
-        params.push({ name: "pagelen", value: perPage });
+      if (Object.keys(params).length === 0) {
+        params.role = "admin";
+        params.pagelen = 100;
       }
 
       // build query
-      const query = params.map((p) => `${p.name}=${p.value}`).join("&");
+      const query = Object.entries(params)
+        .map(([key, value]) => `${key}=${value}`)
+        .join("&");
 
       const request = new Request(`${this.baseurl}${url}?${query}`, {
         headers,

--- a/src/utils/api/Github.js
+++ b/src/utils/api/Github.js
@@ -70,14 +70,25 @@ export default class Github {
    * @param {Number} installationId The id of the installation we'd like to show the repositories.
    * @param {Number} page The page number.
    */
-  repositories({ installationId, page = 1 } = {}) {
+  repositories({ installationId, params = {} } = {}) {
     return new Promise((resolve, reject) => {
       const headers = prepareHeaders(this.accessToken);
       headers.set("Accept", this.previewHeader);
       headers.set("If-None-Match", ""); // https://github.com/octokit/rest.js/issues/890
 
+      // push default params if no params set yet
+      if (Object.keys(params).length === 0) {
+        params.page = 1;
+        params.per_page = 100;
+      }
+
+      // build query
+      const query = Object.entries(params)
+        .map(([key, value]) => `${key}=${value}`)
+        .join("&");
+
       const request = new Request(
-        `${this.baseurl}/user/installations/${installationId}/repositories?page=${page}&per_page=100`,
+        `${this.baseurl}/user/installations/${installationId}/repositories?${query}`,
         { headers }
       );
 


### PR DESCRIPTION
## Pagination for github repositories
### feat: Add pagination for github repositories

Add button to load more bitbucket repositories when creating a new app.
Implementation is similar to load more button of deployments page.
The current page size is set to 100 repositories.
Each trigger of the button loads another 100 repositories.

Relates to: #2, #14

### refactor: Refactor bitbucket provider

Adapt cleaner version of github provider.
Fix bug changing accounts/teams with async / await pattern in setState.

Relates to: #2, #14