### PR TITLE
feat: Add pagination for github repositories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13392,9 +13392,9 @@
       "dev": true
     },
     "query-string": {
-      "version": "6.12.1",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.12.1.tgz",
-      "integrity": "sha512-OHj+zzfRMyj3rmo/6G8a5Ifvw3AleL/EbcHMD27YA31Q+cO5lfmQxECkImuNVjcskLcvBRVHNAB3w6udMs1eAA==",
+      "version": "6.13.2",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.13.2.tgz",
+      "integrity": "sha512-BMmDaUiLDFU1hlM38jTFcRt7HYiGP/zt1sRzrIWm5zpeEuO1rkbPS0ELI3uehoLuuhHDCS8u8lhFN3fEN4JzPQ==",
       "requires": {
         "decode-uri-component": "^0.2.0",
         "split-on-first": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "lodash.get": "^4.4.2",
     "lodash.isequal": "^4.5.0",
     "prop-types": "^15.7.2",
-    "query-string": "^6.3.0",
+    "query-string": "^6.13.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-kawaii": "^0.11.0",

--- a/src/pages/Apps/New/:provider/Provider.bitbucket.js
+++ b/src/pages/Apps/New/:provider/Provider.bitbucket.js
@@ -224,7 +224,7 @@ export default class BitbucketRepositories extends PureComponent {
           <RepoList
             api={api}
             history={history}
-            repositories={items}
+            repositories={repositories}
             provider="bitbucket"
             loading={loading}
             onNextPageClick={this.getRepositories}

--- a/src/pages/Apps/New/:provider/Provider.github.js
+++ b/src/pages/Apps/New/:provider/Provider.github.js
@@ -12,7 +12,7 @@ import Accounts from "./_components/Accounts";
 
 const URL = {
   production: "https://github.com/apps/stormkit-io/installations/new",
-  development: "https://github.com/apps/stormkit-io-dev/installations/new",
+  development: "https://github.com/apps/stormkit-io-dev/installations/new"
 }[process.env.NODE_ENV];
 
 export default class GithubRepos extends PureComponent {
@@ -21,7 +21,7 @@ export default class GithubRepos extends PureComponent {
     history: PropTypes.object,
     loginOauth: PropTypes.func,
     user: PropTypes.object,
-    api: PropTypes.object,
+    api: PropTypes.object
   };
 
   state = {
@@ -33,7 +33,7 @@ export default class GithubRepos extends PureComponent {
     requiresLogin: false,
     loadingInsert: false,
     hasNextPage: false,
-    pageQueryParams: {},
+    pageQueryParams: {}
   };
 
   async componentDidMount() {
@@ -74,11 +74,11 @@ export default class GithubRepos extends PureComponent {
     let selectedAccount;
 
     // List installations. From these installations we will be able to fetch the accounts.
-    insts.installations.forEach((inst) => {
+    insts.installations.forEach(inst => {
       const acc = {
         login: inst.account.login,
         installationId: inst.id,
-        avatar: inst.account.avatar_url,
+        avatar: inst.account.avatar_url
       };
 
       if (g(inst, "account.login") === user.displayName) {
@@ -103,7 +103,7 @@ export default class GithubRepos extends PureComponent {
     return { accounts, selectedAccount };
   };
 
-  connectRepo = (e) => {
+  connectRepo = e => {
     e.preventDefault();
 
     openPopup({
@@ -114,7 +114,7 @@ export default class GithubRepos extends PureComponent {
         const { accounts, selectedAccount } = await this.getInstallations();
         this.updateState({ accounts, selectedAccount });
         this.getRepositories();
-      },
+      }
     });
   };
 
@@ -137,20 +137,14 @@ export default class GithubRepos extends PureComponent {
     // api params
     const defaultParams = {
       page: 1,
-      per_page: 100,
+      per_page: 100
     };
-    const params =
-      Object.keys(pageQueryParams).length > 0 ? pageQueryParams : defaultParams;
 
     // fetch the repositories
     const res = await api.repositories({
       installationId: selectedAccount.installationId,
-      params,
+      params: { ...defaultParams, ...pageQueryParams }
     });
-
-    // adds the current page to the repositories
-    const page = res.repositories;
-    repositories.push(...page);
 
     // check if there is a next page with more repositories
     const hasNextPage =
@@ -160,23 +154,23 @@ export default class GithubRepos extends PureComponent {
     const nextPageParams = hasNextPage
       ? {
           ...pageQueryParams,
-          page: pageQueryParams.page + 1,
+          page: pageQueryParams.page + 1
         }
       : defaultParams;
 
     this.updateState({
-      repositories: repositories,
+      repositories: [...repositories, ...res.repositories],
       loading: false,
       hasNextPage,
-      pageQueryParams: nextPageParams,
+      pageQueryParams: nextPageParams
     });
   };
 
-  onAccountChange = async (login) => {
-    const selectedAccount = this.state.accounts.find((a) => a.login === login);
-    const accounts = this.state.accounts.map((a) => ({
+  onAccountChange = async login => {
+    const selectedAccount = this.state.accounts.find(a => a.login === login);
+    const accounts = [...this.state.accounts].map(a => ({
       ...a,
-      selected: a.login === login,
+      selected: a.login === login
     }));
 
     if (selectedAccount) {
@@ -187,13 +181,14 @@ export default class GithubRepos extends PureComponent {
 
   updateState = (...args) => {
     // wait for the callback to be triggered to resolve the promise to avoid side effects (too) slowly mutating the state
-    return new Promise((resolve) => {
+    return new Promise(resolve => {
       if (this.unmounted !== true) {
         this.setState(...args, () => {
           resolve(true);
         });
+      } else {
+        resolve(true);
       }
-      resolve(true);
     });
   };
 
@@ -209,7 +204,7 @@ export default class GithubRepos extends PureComponent {
       selectedAccount,
       loading,
       requiresLogin,
-      hasNextPage,
+      hasNextPage
     } = this.state;
 
     const { login } = selectedAccount || {};
@@ -221,7 +216,7 @@ export default class GithubRepos extends PureComponent {
             onClick={loginUser({
               loginOauth,
               updateState: (...args) => this.updateState(...args),
-              init: () => this.init(),
+              init: () => this.init()
             })}
           />
         </LoginScreen>

--- a/src/utils/api/Bitbucket.js
+++ b/src/utils/api/Bitbucket.js
@@ -33,20 +33,22 @@ export default class Bitbucket {
    *
    * @param {String} team The name of the team.
    */
-  repositories({ team, perPage = 100, params = [] } = {}) {
+  repositories({ team, params = {} } = {}) {
     const url = team ? `/repositories/${team}` : "/repositories";
 
     return new Promise((resolve, reject) => {
       const headers = prepareHeaders(this.accessToken);
 
       // push default params if no params set yet
-      if (params.length === 0) {
-        params.push({ name: "role", value: "admin" });
-        params.push({ name: "pagelen", value: perPage });
+      if (Object.keys(params).length === 0) {
+        params.role = "admin";
+        params.pagelen = 100;
       }
 
       // build query
-      const query = params.map((p) => `${p.name}=${p.value}`).join("&");
+      const query = Object.entries(params)
+        .map(([key, value]) => `${key}=${value}`)
+        .join("&");
 
       const request = new Request(`${this.baseurl}${url}?${query}`, {
         headers,

--- a/src/utils/api/Bitbucket.js
+++ b/src/utils/api/Bitbucket.js
@@ -1,7 +1,8 @@
+import qs from "query-string";
 import {
   prepareHeaders,
   errTokenExpired,
-  errNotEnoughPermissions,
+  errNotEnoughPermissions
 } from "./helpers";
 
 export default class Bitbucket {
@@ -18,7 +19,7 @@ export default class Bitbucket {
       const headers = prepareHeaders(this.accessToken);
       const request = new Request(this.baseurl + "/user", { headers });
 
-      return fetch(request).then((res) => {
+      return fetch(request).then(res => {
         if (res.status === 401) {
           return reject(errTokenExpired);
         }
@@ -46,15 +47,13 @@ export default class Bitbucket {
       }
 
       // build query
-      const query = Object.entries(params)
-        .map(([key, value]) => `${key}=${value}`)
-        .join("&");
+      const query = qs.stringify(params);
 
       const request = new Request(`${this.baseurl}${url}?${query}`, {
-        headers,
+        headers
       });
 
-      return fetch(request).then((res) => {
+      return fetch(request).then(res => {
         if (res.status === 401) {
           return reject(errTokenExpired);
         }
@@ -71,10 +70,10 @@ export default class Bitbucket {
     return new Promise((resolve, reject) => {
       const headers = prepareHeaders(this.accessToken);
       const request = new Request(this.baseurl + "/teams?role=admin", {
-        headers,
+        headers
       });
 
-      return fetch(request).then((res) => {
+      return fetch(request).then(res => {
         if (res.status === 401) {
           reject(errTokenExpired);
         }

--- a/src/utils/api/Github.js
+++ b/src/utils/api/Github.js
@@ -1,3 +1,4 @@
+import qs from "query-string";
 import { prepareHeaders, errTokenExpired } from "./helpers";
 
 export default class Github {
@@ -23,12 +24,12 @@ export default class Github {
       const headers = prepareHeaders(this.accessToken);
       const request = new Request(`${this.baseurl}/user`, { headers });
 
-      return fetch(request).then((res) => {
+      return fetch(request).then(res => {
         if (res.status === 401) {
           return reject(errTokenExpired);
         }
 
-        return res.json().then((user) => {
+        return res.json().then(user => {
           resolve(user);
         });
       });
@@ -51,7 +52,7 @@ export default class Github {
         { headers }
       );
 
-      return fetch(request).then((res) => {
+      return fetch(request).then(res => {
         if (res.status === 401) {
           return reject(errTokenExpired);
         }
@@ -83,21 +84,19 @@ export default class Github {
       }
 
       // build query
-      const query = Object.entries(params)
-        .map(([key, value]) => `${key}=${value}`)
-        .join("&");
+      const query = qs.stringify(params);
 
       const request = new Request(
         `${this.baseurl}/user/installations/${installationId}/repositories?${query}`,
         { headers }
       );
 
-      return fetch(request).then((res) => {
+      return fetch(request).then(res => {
         if (res.status === 401) {
           return reject(errTokenExpired);
         }
 
-        return res.json().then((repos) => {
+        return res.json().then(repos => {
           resolve(repos);
         });
       });

--- a/src/utils/api/Github.js
+++ b/src/utils/api/Github.js
@@ -70,14 +70,25 @@ export default class Github {
    * @param {Number} installationId The id of the installation we'd like to show the repositories.
    * @param {Number} page The page number.
    */
-  repositories({ installationId, page = 1 } = {}) {
+  repositories({ installationId, params = {} } = {}) {
     return new Promise((resolve, reject) => {
       const headers = prepareHeaders(this.accessToken);
       headers.set("Accept", this.previewHeader);
       headers.set("If-None-Match", ""); // https://github.com/octokit/rest.js/issues/890
 
+      // push default params if no params set yet
+      if (Object.keys(params).length === 0) {
+        params.page = 1;
+        params.per_page = 100;
+      }
+
+      // build query
+      const query = Object.entries(params)
+        .map(([key, value]) => `${key}=${value}`)
+        .join("&");
+
       const request = new Request(
-        `${this.baseurl}/user/installations/${installationId}/repositories?page=${page}&per_page=100`,
+        `${this.baseurl}/user/installations/${installationId}/repositories?${query}`,
         { headers }
       );
 


### PR DESCRIPTION
## Pagination for github repositories
### feat: Add pagination for github repositories

Add button to load more bitbucket repositories when creating a new app.
Implementation is similar to load more button of deployments page.
The current page size is set to 100 repositories.
Each trigger of the button loads another 100 repositories.

Relates to: #2, #14

### refactor: Refactor bitbucket provider

Adapt cleaner version of github provider.
Fix bug changing accounts/teams with async / await pattern in setState.

Relates to: #2, #14