### PR TITLE
Fix: typescript support for tailwind purge

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   purge: {
     enabled: process.env.NODE_ENV === "production",
-    content: ["src/index.js", "src/**/*.js"],
+    content: ["src/index.js", "src/**/*.js", "src/**/*.ts", "src/**/*.tsx"],
     options: {
       whitelist: [
         // Provider related dynamic classes


### PR DESCRIPTION
Apparently typescript files are ignored by tailwind and the classes are not included in the bundle. This PR fixes this bug.