### PR TITLE
Fix: Update publish backend endpoint

### DIFF
--- a/src/pages/apps/[id]/deployments/actions.js
+++ b/src/pages/apps/[id]/deployments/actions.js
@@ -41,7 +41,7 @@ export const publishDeployments = ({ api, app, setPublishError, history }) => (
   }
 
   return api
-    .post(`/app/publish`, {
+    .post(`/app/deployments/publish`, {
       appId: `${app.id}`,
       envId,
       publish,


### PR DESCRIPTION
The backend will soon use the new endpoint to publish deployments. The current endpoint returns a 404 anyways, so there is no problem if we update it beforehand.