### PR TITLE
Create prettierrc config file

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "arrowParens": "avoid",
+  "semi": true,
+  "tabWidth": 2
+}

--- a/src/layouts/CenterLayout.tsx
+++ b/src/layouts/CenterLayout.tsx
@@ -2,7 +2,7 @@ import React, { ReactElement, ReactNode, FC } from "react";
 
 type Props = {
   children: ReactNode;
-}
+};
 
 const DefaultLayout: FC<Props> = ({ children }: Props): ReactElement => (
   <main className="flex flex-col max-w-screen-xl min-h-screen m-auto items-center justify-center">


### PR DESCRIPTION
This creates the `.prettierrc` config file for Prettier.

As prettier doesn't ["support any kind of global configuration"](https://prettier.io/docs/en/configuration.html), prettier might behave in an unexpected way on a different computer. For example, for me it tried added arrow parenthesis although they are avoided in the rest of the project.