### PR TITLE
Feat: add invitation accept page

### DIFF
--- a/src/components/Errors/Error404.tsx
+++ b/src/components/Errors/Error404.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import Link from "~/components/Link";
 import Logo from "~/components/Logo";
 
 const Error404: React.FC = ({ children }): React.ReactElement => {
@@ -9,7 +10,9 @@ const Error404: React.FC = ({ children }): React.ReactElement => {
         {children}
       </div>
       <div className="mt-32">
-        <Logo iconOnly />
+        <Link to="/">
+          <Logo iconOnly />
+        </Link>
       </div>
     </div>
   );

--- a/src/pages/app/invitation/Accept.tsx
+++ b/src/pages/app/invitation/Accept.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { Redirect } from "react-router-dom";
+import { connect } from "~/utils/context";
+import RootContext from "~/pages/Root.context";
+import Error404 from "~/components/Errors/Error404";
+import Api from "~/utils/api/Api";
+import { useParseAppId } from "./actions";
+
+interface Props {
+  api: Api;
+}
+
+const InvitationAccept = ({ api }: Props): React.ReactElement => {
+  const appId = useParseAppId({ api });
+
+  if (appId) {
+    return <Redirect to={`/apps/${appId}/team`} />;
+  }
+
+  return (
+    <Error404>
+      The invitation token is invalid. Make sure that the username and provider
+      match your login credentials.
+    </Error404>
+  );
+};
+
+export default connect(InvitationAccept, [
+  { Context: RootContext, props: ["api"] }
+]);

--- a/src/pages/app/invitation/actions.ts
+++ b/src/pages/app/invitation/actions.ts
@@ -1,0 +1,36 @@
+import { useEffect, useState } from "react";
+import { useLocation } from "react-router-dom";
+import qs from "query-string";
+import Api from "~/utils/api/Api";
+
+interface EnrollProps {
+  api: Api;
+}
+
+interface EnrollResponse {
+  appId: string;
+}
+
+export const useParseAppId = ({ api }: EnrollProps): string => {
+  const location = useLocation();
+  const { token } = qs.parse(location.search);
+  const [appId, setAppId] = useState<string>("");
+
+  useEffect(() => {
+    let unmounted = false;
+
+    api
+      .post<EnrollResponse>("/app/members/enroll", { token })
+      .then(res => {
+        if (!unmounted) {
+          setAppId(res.appId);
+        }
+      });
+
+    return () => {
+      unmounted = true;
+    };
+  }, []);
+
+  return appId;
+};

--- a/src/pages/routes.tsx
+++ b/src/pages/routes.tsx
@@ -30,6 +30,10 @@ const routes: Array<RouteProps> = [
     component: Async(() => import("~/pages/apps/new/[provider]"))
   },
   {
+    path: "/app/invitation/accept",
+    component: Async(() => import("~/pages/app/invitation/Accept"))
+  },
+  {
     path: "/app/:id",
     component: (): React.ReactElement => {
       const { pathname } = useLocation();


### PR DESCRIPTION
This PR adds a page which handles team invitations. It'll parse the token provided in the URL and make a request to the backend. If everything looks fine, it'll redirect the user to the application's team page. Otherwise it will display a 404 page with a custom error message.