### PR TITLE
Fix: environment page being blank

### DIFF
--- a/src/pages/apps/[id]/environments/_components/EnvironmentFormModal.spec.js
+++ b/src/pages/apps/[id]/environments/_components/EnvironmentFormModal.spec.js
@@ -11,7 +11,7 @@ describe(fileName, () => {
   const path = `~/${fileName}`;
   let wrapper;
 
-  describe("when environment object is empty", () => {
+  describe("when environment object is empty - create mode", () => {
     let app;
 
     beforeEach(() => {
@@ -45,6 +45,10 @@ describe(fileName, () => {
       };
 
       const scope = nocks.mockInsertEnvironment({ environment });
+
+      // Add a new row
+      fireEvent.click(wrapper.getByLabelText("Add new environment variable"));
+
       const envKey = wrapper.getByLabelText("Environment variable name 0");
       const envVal = wrapper.getByLabelText("Environment variable value 0");
       const buildCmd = wrapper.getByLabelText("Build command");

--- a/src/pages/apps/[id]/environments/actions.tsx
+++ b/src/pages/apps/[id]/environments/actions.tsx
@@ -158,6 +158,7 @@ export const useFetchStatus = ({
 
 interface Meta {
   type: "-" | "nuxt" | "next" | "angular";
+  packageJson?: boolean;
 }
 
 interface FetchRepoTypeProps {

--- a/testing/nocks/nock_environment.js
+++ b/testing/nocks/nock_environment.js
@@ -45,6 +45,7 @@ export const mockUpdateEnvironment = ({
   nock(endpoint)
     .put(`/app/env`, {
       appId: environment.appId,
+      envId: environment.id,
       env: environment.env,
       branch: environment.branch,
       autoPublish: environment.autoPublish,


### PR DESCRIPTION
When the environment variables are wiped out and the form is submitted, the environment page shows blank. This commit fixes that issue. Also, it migrates the EnvironmentFormModal file to typescript.

Issue: https://github.com/stormkit-io/app-stormkit-io/issues/157

![env-var-fixed](https://user-images.githubusercontent.com/3321893/134805026-3ee5d3af-e80f-4c41-ab07-00673cc53f12.gif)