### PR TITLE
fix: renaming environment name

### DIFF
--- a/src/pages/apps/[id]/environments/_components/EnvironmentFormModal.tsx
+++ b/src/pages/apps/[id]/environments/_components/EnvironmentFormModal.tsx
@@ -260,8 +260,8 @@ const EnvironmentFormModal: React.FC<Props & ModalContextProps> = ({
             />
             <div className="p-3 text-sm opacity-50">
               The command to build your application. You can chain multiple
-              commands with the <b>&amp;&amp;</b> operator. (i.e. npm build &&
-              npm start)
+              commands with the <b>&amp;&amp;</b> operator. (i.e. npm run test
+              &amp;&amp; npm run build)
             </div>
           </div>
           <h3 className="mt-8 font-bold">Environment variables</h3>

--- a/testing/nocks/nock_environment.js
+++ b/testing/nocks/nock_environment.js
@@ -45,7 +45,7 @@ export const mockUpdateEnvironment = ({
   nock(endpoint)
     .put(`/app/env`, {
       appId: environment.appId,
-      envId: environment.id,
+      id: environment.id,
       env: environment.env,
       branch: environment.branch,
       autoPublish: environment.autoPublish,


### PR DESCRIPTION
Fixes #172.

This PR fixes renaming an environment name. Previously, when renamed, nothing would happen. Now it successfully renames the environment. Production environments cannot be renamed:

![fix-renaming-env](https://user-images.githubusercontent.com/3321893/138358178-2103d6e9-8dbc-4b2e-8d06-2cfd4121ba2d.gif)


