### PR TITLE
feat: ask for build config on deploy

### DIFF
--- a/src/pages/apps/[id]/environments/actions.tsx
+++ b/src/pages/apps/[id]/environments/actions.tsx
@@ -160,14 +160,15 @@ export const useFetchStatus = ({
 };
 
 interface Meta {
-  type: "-" | "nuxt" | "next" | "angular";
+  type: "nuxt" | "next" | "react" | "vue" | "angular" | "nest" | "-";
   packageJson?: boolean;
+  isFramework?: boolean;
 }
 
 interface FetchRepoTypeProps {
   api: Api;
   app: App;
-  env: Environment;
+  env?: Environment;
 }
 
 interface FetchRepoTypeReturnValue {
@@ -188,6 +189,16 @@ export const useFetchRepoType = ({
 
   useEffect(() => {
     let unmounted = false;
+
+    // For the production environment we fetch the meta information while
+    // fetching the application. Therefore, we do not need to re-fetch it.
+    if (name === "production" && app.meta) {
+      return setMeta({
+        type: app.meta.repoType,
+        packageJson: app.meta.hasPackageJson,
+        isFramework: app.meta.isFramework,
+      });
+    }
 
     setLoading(true);
 

--- a/src/pages/apps/_components/DeployModal.spec.js
+++ b/src/pages/apps/_components/DeployModal.spec.js
@@ -1,6 +1,7 @@
 import * as lib from "@testing-library/react";
 import router from "react-router";
 import nock from "nock";
+import userEvent from "@testing-library/user-event";
 import { withMockContext } from "~/testing/helpers";
 import * as data from "~/testing/data";
 
@@ -47,6 +48,9 @@ describe(fileName, () => {
         appId: `${app.id}`,
         env: "production",
         branch: "master",
+        distFolder: "my-dist",
+        cmd: "echo hi",
+        publish: true,
       })
       .reply(status, { ok: true, id });
 
@@ -75,13 +79,19 @@ describe(fileName, () => {
       fireEvent.click(option);
     });
 
-    expect(
-      wrapper.getByText(
-        "This environment has Auto Publish turned on. This deployment will be published if it is successful."
-      )
-    ).toBeTruthy();
+    const buildFolder = wrapper.getByLabelText("Build Folder");
+    const branch = wrapper.getByLabelText("Branch to deploy");
+    const cmd = wrapper.getByLabelText("Cmd to execute");
+    expect(buildFolder.value).toBe("packages/console/dist");
+    expect(branch.value).toBe("master");
+    expect(cmd.value).toBe("yarn test && yarn run build:console");
 
-    document.body.querySelector("[name=branch]").value = "master";
+    userEvent.clear(buildFolder);
+    userEvent.clear(branch);
+    userEvent.clear(cmd);
+    userEvent.type(buildFolder, "my-dist");
+    userEvent.type(branch, "master");
+    userEvent.type(cmd, "echo hi");
 
     fireEvent.click(wrapper.getByText("Deploy now"));
 

--- a/src/types/app.d.ts
+++ b/src/types/app.d.ts
@@ -14,4 +14,9 @@ declare type App = {
   commitPrefix?: string;
   provider: "github" | "bitbucket" | "gitlab";
   name?: string;
+  meta?: {
+    isFramework: boolean;
+    hasPackageJson: boolean;
+    repoType: "nuxt" | "next" | "react" | "vue" | "angular" | "nest" | "-";
+  };
 };


### PR DESCRIPTION
Fixes #116.

The deploy modal now displays additional fields in order to make the onboarding easier. Usually, the environment configuration went unnoticed, resulting in many failed deployments. With these changes, it should now be easier to deploy. This feature also allows to overwrite custom configuration per deployment.

Here's how it looks like: 

![image](https://user-images.githubusercontent.com/3321893/138611750-0fb9b53d-8bfc-4e91-936e-e53bb4ab7f73.png)
