### PR TITLE
refactor: move logic to key-value component

### DIFF
--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -9,6 +9,7 @@ import Toggler from "./Toggler";
 import Switch from "./Switch";
 import Helper from "./Helper";
 import Header from "./Header";
+import KeyValue from "./KeyValue";
 import Section from "./components/Section";
 import Description from "./components/Description";
 import CodeMirror from "@uiw/react-codemirror";
@@ -136,5 +137,6 @@ Form.Section = Section;
 Form.Description = Description;
 Form.Helper = Helper;
 Form.Header = Header;
+Form.KeyValue = KeyValue;
 
 export default Form;

--- a/src/components/Form/KeyValue.tsx
+++ b/src/components/Form/KeyValue.tsx
@@ -1,0 +1,143 @@
+import React, { useEffect, useState } from "react";
+import Input from "./Input";
+import Button from "~/components/Button";
+
+/**
+ * This function generates alternative keys for the values array
+ * in order to help React remember the form state whenever the rows
+ * change. Each time a new row is added, Date.now() is assigned to
+ * that rows altKey property. If this property misses - first render for
+ * instance - then the array index is assigned.
+ */
+const generateAltKeys = (vals: Array<KeyValue>): Array<KeyValue> => {
+  return vals.map((value, i) => ({
+    ...value,
+    altKey: value.altKey ?? i,
+  }));
+};
+
+interface KeyValue {
+  key: string;
+  value: string;
+  altKey?: number;
+}
+
+interface Props {
+  keyInputName: string;
+  valueInputName: string;
+  keyLabel: string;
+  valueLabel: string;
+  keyAriaLabel?: string;
+  valueAriaLabel?: string;
+  defaultValues?: Array<KeyValue>;
+  plusButtonAriaLabel?: string;
+  onChange: (val: Array<KeyValue>) => void;
+}
+
+const KeyValue: React.FC<Props> = ({
+  keyInputName,
+  valueInputName,
+  defaultValues = [],
+  keyLabel,
+  valueLabel,
+  keyAriaLabel,
+  valueAriaLabel,
+  plusButtonAriaLabel,
+  onChange,
+}): React.ReactElement => {
+  const [values, setValues] = useState<Array<KeyValue>>(
+    generateAltKeys(defaultValues)
+  );
+
+  useEffect(() => {
+    if (defaultValues?.length === 0) {
+      setValues([{ key: "", value: "", altKey: Date.now() }]);
+    } else {
+      setValues(generateAltKeys(defaultValues));
+    }
+  }, [defaultValues]);
+
+  return (
+    <>
+      {values.map(({ key, value, altKey }, i) => (
+        <div className="flex justify-between mb-2 relative" key={altKey}>
+          <div className="flex flex-auto items-center mr-2">
+            {i === values.length - 1 && (
+              <Button
+                styled={false}
+                className="absolute left-0 -ml-6"
+                type="button"
+                aria-label={plusButtonAriaLabel}
+                onClick={() => {
+                  onChange([
+                    ...values,
+                    { key: "", value: "", altKey: Date.now() },
+                  ]);
+                }}
+              >
+                <span className="fas fa-plus-circle" />
+              </Button>
+            )}
+            <Input
+              name={keyInputName}
+              label={keyLabel}
+              multiline
+              className="bg-gray-90"
+              defaultValue={key}
+              fullWidth
+              onBlur={e => {
+                const copy = values.slice(0);
+                copy[i].key = e.target.value;
+                onChange(copy);
+              }}
+              inputProps={
+                keyAriaLabel
+                  ? {
+                      "aria-label": `${keyAriaLabel} ${i}`,
+                    }
+                  : undefined
+              }
+            />
+          </div>
+          <div className="flex flex-auto items-center max-w-1/2 relative">
+            <Input
+              name={valueInputName}
+              label={valueLabel}
+              multiline
+              className="bg-gray-90"
+              defaultValue={value}
+              fullWidth
+              onBlur={e => {
+                const copy = values.slice(0);
+                copy[i].value = e.target.value;
+                onChange(copy);
+              }}
+              inputProps={
+                valueAriaLabel
+                  ? {
+                      "aria-label": `${valueAriaLabel} ${i}`,
+                    }
+                  : undefined
+              }
+            />
+
+            <Button
+              styled={false}
+              className="absolute right-0 -mr-6"
+              type="button"
+              onClick={() => {
+                const copy = values.slice(0);
+                copy.splice(i, 1);
+                onChange(copy);
+              }}
+            >
+              <span className="fas fa-minus-circle red-50" />
+            </Button>
+          </div>
+        </div>
+      ))}
+    </>
+  );
+};
+
+export default KeyValue;

--- a/src/pages/apps/[id]/environments/_components/EnvironmentFormModal.tsx
+++ b/src/pages/apps/[id]/environments/_components/EnvironmentFormModal.tsx
@@ -7,7 +7,6 @@ import Form from "~/components/Form";
 import Button from "~/components/Button";
 import InfoBox from "~/components/InfoBox";
 import ConfirmModal, { ConfirmModalProps } from "~/components/ConfirmModal";
-import { PlusButton } from "~/components/Buttons";
 import { connect } from "~/utils/context";
 import {
   insertEnvironment,
@@ -219,55 +218,16 @@ const EnvironmentFormModal: React.FC<Props & ModalContextProps> = ({
             process.
           </div>
           <div className="mb-8" id="env-vars">
-            {envVars.map(({ key, value }, i) => (
-              <div className="flex justify-between mb-2" key={`${key}${i}`}>
-                <div className="flex-auto mr-2">
-                  <Form.Input
-                    name="build.vars.keys"
-                    label="Key"
-                    multiline
-                    className="bg-gray-90"
-                    defaultValue={key}
-                    fullWidth
-                    inputProps={{
-                      "aria-label": `Environment variable name ${i}`,
-                    }}
-                  />
-                </div>
-                <div className="flex flex-auto items-center max-w-1/2 relative">
-                  <Form.Input
-                    name="build.vars.values"
-                    label="Value"
-                    multiline
-                    className="bg-gray-90"
-                    defaultValue={value}
-                    fullWidth
-                    inputProps={{
-                      "aria-label": `Environment variable value ${i}`,
-                    }}
-                  />
-                  <Button
-                    styled={false}
-                    className="absolute right-0 -mr-6"
-                    type="button"
-                    onClick={() => {
-                      const copy = envVars.slice(0);
-                      copy.splice(i, 1);
-                      setEnvVars(copy);
-                    }}
-                  >
-                    <span className="fas fa-minus-circle red-50" />
-                  </Button>
-                </div>
-              </div>
-            ))}
-            <PlusButton
-              className="mt-2"
-              size="small"
-              aria-label="Add new environment variable"
-              onClick={() => {
-                setEnvVars([...envVars, { key: "", value: "" }]);
-              }}
+            <Form.KeyValue
+              defaultValues={envVars}
+              keyInputName="build.vars.keys"
+              valueInputName="build.vars.values"
+              keyLabel="Key"
+              valueLabel="Value"
+              keyAriaLabel="Environment variable name"
+              valueAriaLabel="Environment variable value"
+              plusButtonAriaLabel="Add new environment variable"
+              onChange={setEnvVars}
             />
           </div>
           {error && (

--- a/src/pages/apps/[id]/environments/helpers.ts
+++ b/src/pages/apps/[id]/environments/helpers.ts
@@ -10,7 +10,9 @@ export const prepareBuildObject = (
   const vals = toArray<string>(values["build.vars.values"]);
 
   keys.forEach((key, i) => {
-    vars[key] = vals[i].replace(/^['"]+|['"]+$/g, "");
+    if (key.trim() !== "") {
+      vars[key.trim()] = vals[i].trim().replace(/^['"]+|['"]+$/g, "");
+    }
   });
 
   const build: BuildConfig = {


### PR DESCRIPTION
@eldemcan I have refactored the environment variables part and moved that logic to the form component. This way we can reuse this logic in outbound webhooks. 

![env-variables](https://user-images.githubusercontent.com/3321893/153611267-e5e2b360-73af-4791-a1b3-6548939b7432.gif)
