### PR TITLE
fix: check if the app has ever been deployed

### DIFF
--- a/src/pages/apps/_components/AppHeader.tsx
+++ b/src/pages/apps/_components/AppHeader.tsx
@@ -33,7 +33,9 @@ const AppHeader: React.FC<Props> = ({ app, envs, api }): React.ReactElement => {
             </Link>
           </div>
           <div className="text-secondary text-sm">
-            Last deploy: {formattedDate(app.deployedAt)}
+            {app.deployedAt
+              ? `Last deploy: ${formattedDate(app.deployedAt)}`
+              : "Not yet deployed"}
             <span
               className={`inline-block ml-2 w-2 h-2 rounded-full bg-${
                 app.status ? "green-50" : "red-50"


### PR DESCRIPTION
If the app has never been deployed show "Not yet deployed" instead of the unix start time.

Refers to #300 

![image](https://user-images.githubusercontent.com/37296364/155199746-6295e92d-8c5d-49af-83c0-03d1fe4898ec.png)
