### PR TITLE
fix: update link of trigger deploys on env change

### DIFF
--- a/src/components/CopyBox/CopyBox.tsx
+++ b/src/components/CopyBox/CopyBox.tsx
@@ -11,7 +11,7 @@ const CopyBox: FC<Props> = ({ value }: Props): ReactElement => (
     <Form.Input
       multiline
       id="copy-token"
-      defaultValue={value}
+      value={value}
       className="flex-auto"
       inputProps={{
         "aria-label": "Copy token",


### PR DESCRIPTION
The trigger deploy link wasn't updating because it was set using the defaultValue property.

```defaultValue``` only specifies the value when the input is initially created
[https://github.com/facebook/react/issues/4101#issuecomment-111307019](https://github.com/facebook/react/issues/4101#issuecomment-111307019)

Fixes #226