### PR TITLE
fix: use environment id for trigger deploy

### DIFF
--- a/src/pages/apps/[id]/settings/_components/FormTriggerDeploys.tsx
+++ b/src/pages/apps/[id]/settings/_components/FormTriggerDeploys.tsx
@@ -66,7 +66,7 @@ const FormTriggerDeploys: React.FC<Props> = ({
               defaultValue={defaultValue}
               environments={environments}
               placeholder="Choose a build configuration"
-              onSelect={e => setSelectedEnvironment(e?.env)}
+              onSelect={e => setSelectedEnvironment(e?.id)}
             />
             {selectedEnvironment && (
               <>


### PR DESCRIPTION
When the environment is changed, use the environment id instead of the environment name in the Trigger Deploy form.

