### PR TITLE
Fixed renaming a repository on the settings page

### DIFF
--- a/src/pages/apps/[id]/settings/_components/FormAppSettings.tsx
+++ b/src/pages/apps/[id]/settings/_components/FormAppSettings.tsx
@@ -68,6 +68,7 @@ const FormAppSettings: React.FC<Props> = ({ api, app, additionalSettings }) => {
       </Form.Section>
       <Form.Section label="Repository">
         <Form.Input
+          key={toRepoAddr(app.repo)}
           name="repo"
           className="bg-gray-90"
           required


### PR DESCRIPTION
Since we are using defaultValue and that doesn't re-render the component assigning a key will force the component to render.

Fixes #337 