### PR TITLE
refactor: specify layouts directly from the routes file

### DIFF
--- a/src/components/Async/Async.tsx
+++ b/src/components/Async/Async.tsx
@@ -2,14 +2,30 @@ import React, { Suspense } from "react";
 import Spinner from "~/components/Spinner";
 import "./Async.css";
 
+interface Props {
+  children: React.ReactNode;
+}
+
 const Async = (
-  dynamicImport: () => Promise<{ default: React.FC }>
+  dynamicImport: () => Promise<{ default: React.FC }>,
+  layoutImport?: () => Promise<{ default: React.FC<Props> }>
 ): React.ReactNode => {
   const Component = React.lazy(dynamicImport);
+  let LayoutComponent: React.LazyExoticComponent<React.FC<Props>> | null = null;
+
+  if (layoutImport) {
+    LayoutComponent = React.lazy(layoutImport);
+  }
 
   return (
     <Suspense fallback={<Spinner pageCenter />}>
-      <Component />
+      {LayoutComponent ? (
+        <LayoutComponent>
+          <Component />
+        </LayoutComponent>
+      ) : (
+        <Component />
+      )}
     </Suspense>
   );
 };

--- a/src/pages/apps/Apps.tsx
+++ b/src/pages/apps/Apps.tsx
@@ -2,7 +2,6 @@ import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { LocalStorage } from "~/utils/storage";
 import { LS_PROVIDER } from "~/utils/api/Api";
-import CenterLayout from "~/layouts/CenterLayout";
 import AppName from "~/components/AppName";
 import Button from "~/components/ButtonV2";
 import Container from "~/components/Container";
@@ -33,18 +32,16 @@ export const Home: React.FC = () => {
 
   if (apps.length === 0 && !loading && !filter) {
     return (
-      <CenterLayout>
-        <Container className="flex flex-1 items-center justify-center">
-          <EmptyList actionLink={newAppHref} />
-        </Container>
-      </CenterLayout>
+      <Container className="flex flex-1 items-center justify-center">
+        <EmptyList actionLink={newAppHref} />
+      </Container>
     );
   }
 
   const isLoadingFirstTime = loading && apps.length === 0;
 
   return (
-    <CenterLayout>
+    <>
       <Container
         className={"flex-1"}
         title="My apps"
@@ -138,7 +135,7 @@ export const Home: React.FC = () => {
           welcomeModalId={welcomeModalId}
         />
       )}
-    </CenterLayout>
+    </>
   );
 };
 

--- a/src/pages/apps/new/bitbucket/NewBitbucketApp.tsx
+++ b/src/pages/apps/new/bitbucket/NewBitbucketApp.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from "react";
-import CenterLayout from "~/layouts/CenterLayout";
 import { BackButton } from "~/components/Buttons";
 import Container from "~/components/Container";
 import RepoList from "../_components/RepoList";
@@ -12,29 +11,26 @@ const Provider: React.FC = () => {
   });
 
   return (
-    <CenterLayout>
-      <Container
-        className="flex-1"
-        title={
-          <>
-            <BackButton to="/" className="ml-0 mr-2" /> Import app from
-            Bitbucket
-          </>
-        }
-      >
-        <div className="p-4 pt-0">
-          <RepoList
-            repositories={repos}
-            provider="bitbucket"
-            error={error}
-            loading={loading}
-            isLoadingMore={isLoadingMore}
-            hasNextPage={hasNextPage}
-            onNextPage={() => setPage(page + 1)}
-          />
-        </div>
-      </Container>
-    </CenterLayout>
+    <Container
+      className="flex-1"
+      title={
+        <>
+          <BackButton to="/" className="ml-0 mr-2" /> Import app from Bitbucket
+        </>
+      }
+    >
+      <div className="p-4 pt-0">
+        <RepoList
+          repositories={repos}
+          provider="bitbucket"
+          error={error}
+          loading={loading}
+          isLoadingMore={isLoadingMore}
+          hasNextPage={hasNextPage}
+          onNextPage={() => setPage(page + 1)}
+        />
+      </div>
+    </Container>
   );
 };
 

--- a/src/pages/apps/new/github/NewGithubApp.spec.tsx
+++ b/src/pages/apps/new/github/NewGithubApp.spec.tsx
@@ -123,7 +123,7 @@ describe("~/pages/apps/new/github/NewGithubApp.tsx", () => {
         expect(wrapper.getByText("simple-project")).toBeTruthy();
       });
 
-      const input = wrapper.getAllByRole("button").at(3);
+      const input = wrapper.getAllByRole("button").at(1);
       expect(input).toBeTruthy();
       fireEvent.mouseDown(input!);
 

--- a/src/pages/apps/new/github/NewGithubApp.tsx
+++ b/src/pages/apps/new/github/NewGithubApp.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useContext, useEffect } from "react";
-import CenterLayout from "~/layouts/CenterLayout";
 import { AuthContext } from "~/pages/auth/Auth.context";
 import { BackButton } from "~/components/Buttons";
 import Button from "~/components/ButtonV2";
@@ -58,58 +57,56 @@ const Provider: React.FC = () => {
   }, [accounts, user?.displayName]);
 
   return (
-    <CenterLayout>
-      <Container
-        className="flex-1"
-        title={
-          <>
-            <BackButton to="/" className="ml-0 mr-2" /> Import app from GitHub
-          </>
-        }
-        actions={
-          <Button
-            category="action"
-            onClick={() => {
-              openPopup({
-                url: openPopupURL,
-                title: "Add repository",
-                width: 1000,
-                onClose: () => {
-                  setInstallationId(undefined);
-                  setRefreshToken(Date.now());
-                },
-              });
+    <Container
+      className="flex-1"
+      title={
+        <>
+          <BackButton to="/" className="ml-0 mr-2" /> Import app from GitHub
+        </>
+      }
+      actions={
+        <Button
+          category="action"
+          onClick={() => {
+            openPopup({
+              url: openPopupURL,
+              title: "Add repository",
+              width: 1000,
+              onClose: () => {
+                setInstallationId(undefined);
+                setRefreshToken(Date.now());
+              },
+            });
+          }}
+        >
+          Connect more repositories
+        </Button>
+      }
+    >
+      <div className="p-4 pt-0">
+        <div className="flex mb-4">
+          <Accounts
+            loading={faLoading}
+            accounts={accounts}
+            selected={installationId}
+            onAccountChange={id => {
+              setPage(1);
+              setInstallationId(id);
             }}
-          >
-            Connect more repositories
-          </Button>
-        }
-      >
-        <div className="p-4 pt-0">
-          <div className="flex mb-4">
-            <Accounts
-              loading={faLoading}
-              accounts={accounts}
-              selected={installationId}
-              onAccountChange={id => {
-                setPage(1);
-                setInstallationId(id);
-              }}
-            />
-          </div>
-
-          <RepoList
-            repositories={repos}
-            provider="github"
-            error={error}
-            loading={loading}
-            isLoadingMore={isLoadingMore}
-            hasNextPage={hasNextPage}
-            onNextPage={() => setPage(page + 1)}
           />
         </div>
-      </Container>
-    </CenterLayout>
+
+        <RepoList
+          repositories={repos}
+          provider="github"
+          error={error}
+          loading={loading}
+          isLoadingMore={isLoadingMore}
+          hasNextPage={hasNextPage}
+          onNextPage={() => setPage(page + 1)}
+        />
+      </div>
+    </Container>
   );
 };
 

--- a/src/pages/apps/new/gitlab/NewGitlabApp.tsx
+++ b/src/pages/apps/new/gitlab/NewGitlabApp.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from "react";
-import CenterLayout from "~/layouts/CenterLayout";
 import { BackButton } from "~/components/Buttons";
 import Container from "~/components/Container";
 import RepoList from "../_components/RepoList";
@@ -12,28 +11,26 @@ const Provider: React.FC = () => {
   });
 
   return (
-    <CenterLayout>
-      <Container
-        className="flex-1"
-        title={
-          <>
-            <BackButton to="/" className="ml-0 mr-2" /> Import app from GitLab
-          </>
-        }
-      >
-        <div className="p-4 pt-0">
-          <RepoList
-            repositories={repos}
-            provider="gitlab"
-            error={error}
-            loading={loading}
-            isLoadingMore={isLoadingMore}
-            hasNextPage={hasNextPage}
-            onNextPage={() => setPage(page + 1)}
-          />
-        </div>
-      </Container>
-    </CenterLayout>
+    <Container
+      className="flex-1"
+      title={
+        <>
+          <BackButton to="/" className="ml-0 mr-2" /> Import app from GitLab
+        </>
+      }
+    >
+      <div className="p-4 pt-0">
+        <RepoList
+          repositories={repos}
+          provider="gitlab"
+          error={error}
+          loading={loading}
+          isLoadingMore={isLoadingMore}
+          hasNextPage={hasNextPage}
+          onNextPage={() => setPage(page + 1)}
+        />
+      </div>
+    </Container>
   );
 };
 

--- a/src/pages/auth/Auth.tsx
+++ b/src/pages/auth/Auth.tsx
@@ -1,7 +1,6 @@
 import React, { useContext, useEffect } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import qs from "query-string";
-import CenterLayout from "~/layouts/CenterLayout";
 import Logo from "~/components/Logo";
 import { AuthContext } from "./Auth.context";
 import InfoBox from "~/components/InfoBoxV2";
@@ -36,7 +35,7 @@ const Auth: React.FC = () => {
   }
 
   return (
-    <CenterLayout>
+    <>
       <div className="mb-16 text-center pt-6 sm:pt-0">
         <Logo iconOnly iconSize={20} />
       </div>
@@ -84,7 +83,7 @@ const Auth: React.FC = () => {
           </div>
         </div>
       </div>
-    </CenterLayout>
+    </>
   );
 };
 

--- a/src/pages/routes.tsx
+++ b/src/pages/routes.tsx
@@ -26,14 +26,27 @@ const RedirectNewApp: React.FC = () => {
   return <></>;
 };
 
+const RedirectToEnvPage: React.FC = () => {
+  const navigate = useNavigate();
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    navigate(`${pathname}/environments`);
+  }, [navigate]);
+
+  return <></>;
+};
+
+const centerLayout = () => import("~/layouts/CenterLayout");
+
 const routes: Array<RouteProps> = [
   {
     path: "/",
-    element: Async(() => import("~/pages/apps")),
+    element: Async(() => import("~/pages/apps"), centerLayout),
   },
   {
     path: "/auth",
-    element: Async(() => import("~/pages/auth")),
+    element: Async(() => import("~/pages/auth"), centerLayout),
   },
   {
     path: "/logout",
@@ -45,15 +58,15 @@ const routes: Array<RouteProps> = [
   },
   {
     path: "/apps/new/github",
-    element: Async(() => import("~/pages/apps/new/github")),
+    element: Async(() => import("~/pages/apps/new/github"), centerLayout),
   },
   {
     path: "/apps/new/gitlab",
-    element: Async(() => import("~/pages/apps/new/gitlab")),
+    element: Async(() => import("~/pages/apps/new/gitlab"), centerLayout),
   },
   {
     path: "/apps/new/bitbucket",
-    element: Async(() => import("~/pages/apps/new/bitbucket")),
+    element: Async(() => import("~/pages/apps/new/bitbucket"), centerLayout),
   },
   {
     path: "/app/invitation/accept",
@@ -62,6 +75,10 @@ const routes: Array<RouteProps> = [
   {
     path: "/app/:id/*",
     element: <RedirectApps />,
+  },
+  {
+    path: "/apps/:id",
+    element: <RedirectToEnvPage />,
   },
   {
     path: "/apps/:id/*",


### PR DESCRIPTION
Instead of including the layouts from the Route file, specify it as a lazy import when defining a route. This change allows us to wrap the file with the layout with a logic. It also beneficial for the tests because the layout won't generate unneeded markup anymore.