### PR TITLE
chore: improve domain validation setup

### DIFF
--- a/src/pages/apps/[id]/environments/[env-id]/domain/_components/DomainVerificationStatus.tsx
+++ b/src/pages/apps/[id]/environments/[env-id]/domain/_components/DomainVerificationStatus.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from "react";
-import { parse } from "tldts";
 import Table from "@mui/material/Table";
 import TableBody from "@mui/material/TableBody";
 import TableCell from "@mui/material/TableCell";
@@ -15,11 +14,6 @@ interface Props {
     setError: SetError;
   }) => Promise<void>;
 }
-
-const recordName = (domain: Domain): string => {
-  const parsed = parse(domain.domainName);
-  return `${domain.dns.txt.name}.${parsed.subdomain || parsed.domain}`;
-};
 
 const DomainVerificationStatus: React.FC<Props> = ({
   domain,
@@ -58,7 +52,7 @@ const DomainVerificationStatus: React.FC<Props> = ({
                       TXT Record Name/Host
                     </TableCell>
                     <TableCell className="font-bold">
-                      {recordName(domain)}
+                      {domain.dns.txt.name}
                     </TableCell>
                   </TableRow>
                   <TableRow>


### PR DESCRIPTION
Stormkit generates txt hostname and value for validating domain names and ask user ot add these values to their dns provider.

For the txt host name we follow <hash>.<domain> format. For example if user wants to validate vsk.me stormkit will ask to add txt record with hostname <hash>.vsk.me

This is a wrong directive because just adding hash as hostname would be enough. Providers concatanate domain name automatically.

<img width="871" alt="image" src="https://user-images.githubusercontent.com/2489876/190926500-33546ff6-26ca-40a5-a464-2fa405b69f0b.png">

As it can be seen from image adding 1234 as hostname and cloudflare already added `.gigs4peeps.com` if we add 1234.gigs4.peeps has txt name cloudflare will omit that.  Problem occurs with other domain providers such as namecheap unlike cloudflare and godady they don't omit **1234.gigs4.peeps** which causes conflic with root level txt name. By suggesting user to just use hash as txt domain name we solve this problem


