### PR TITLE
feat: close modals when clicking outside

### DIFF
--- a/src/components/OutsideClick/OutsideClick.tsx
+++ b/src/components/OutsideClick/OutsideClick.tsx
@@ -1,34 +1,29 @@
-import { ReactNode, PureComponent } from "react";
-import ReactDOM from "react-dom";
+import React, { useRef, useEffect } from "react";
 
 interface Props {
   handler: (arg0: any) => void;
   children: React.ReactNode;
 }
 
-class OutsideClick extends PureComponent<Props, any> {
-  componentDidMount() {
-    document.addEventListener("click", this.handleClick);
-  }
+export default function OutsideClick(props: Props) {
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const { handler } = props;
 
-  componentWillUnmount() {
-    if (typeof document !== "undefined") {
-      document.removeEventListener("click", this.handleClick);
+  useEffect(() => {
+    function handleClickOutside(event: Event): void {
+      if (
+        event.target != null &&
+        wrapperRef.current &&
+        !wrapperRef.current.contains(event.target as Node)
+      ) {
+        handler(event);
+      }
     }
-  }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [wrapperRef]);
 
-  handleClick = (event: any) => {
-    const root = ReactDOM.findDOMNode(this);
-    const { handler } = this.props;
-
-    if (root && !root.contains(event.target)) {
-      handler(event);
-    }
-  };
-
-  render(): ReactNode {
-    return this.props.children;
-  }
+  return <div ref={wrapperRef}>{props.children}</div>;
 }
-
-export default OutsideClick;

--- a/src/layouts/_components/OutsideRefAlerter.tsx
+++ b/src/layouts/_components/OutsideRefAlerter.tsx
@@ -1,0 +1,34 @@
+import React, { useRef, useEffect } from "react";
+
+/**
+ * Hook that alerts clicks outside of the passed ref
+ */
+function useOutsideAlerter(ref) {
+  useEffect(() => {
+    /**
+     * Alert if clicked on outside of element
+     */
+    function handleClickOutside(event) {
+      console.log(event)
+      if (ref.current && !ref.current.contains(event.target)) {
+        console.log("You clicked outside of me!");
+      }
+    }
+    // Bind the event listener
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      // Unbind the event listener on clean up
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [ref]);
+}
+
+/**
+ * Component that alerts if you click outside of it
+ */
+export default function OutsideAlerter(props) {
+  const wrapperRef = useRef(null);
+  useOutsideAlerter(wrapperRef);
+
+  return <div ref={wrapperRef}>{props.children}</div>;
+}

--- a/src/layouts/_components/UserButtons.tsx
+++ b/src/layouts/_components/UserButtons.tsx
@@ -4,14 +4,13 @@ import Button from "~/components/ButtonV2";
 import SideBar from "~/components/SideBar";
 import UserMenu from "~/components/UserMenu";
 import { Tooltip } from "@mui/material";
+import OutsideClick from "~/components/OutsideClick/OutsideClick";
 
 const UserButtons: React.FC = () => {
   const { user } = useContext(AuthContext);
   const [isNewsOpen, toggleNews] = useState(false);
   const [isUserMenuOpen, toggleUserMenu] = useState(false);
-
-  const isLocal = () =>
-    process.env.STORMKIT_ENV == "local";
+  const isLocal = () => process.env.STORMKIT_ENV == "local";
 
   const isCanary = () =>
     window.document.cookie.indexOf("sk_canary=true") > -1 ? true : false;
@@ -30,78 +29,94 @@ const UserButtons: React.FC = () => {
     <>
       {user.isAdmin && (
         <span className="text-center">
-            <div
-              onClick={() => (isCanary() ? disableCanary() : enableCanary())}
-            >
-              { isCanary() ? "Canary" : isLocal() ? "Local" : "Prod" }
-            </div>
+          <div onClick={() => (isCanary() ? disableCanary() : enableCanary())}>
+            {isCanary() ? "Canary" : isLocal() ? "Local" : "Prod"}
+          </div>
         </span>
       )}
-      <Tooltip
-        title={
-          <Button
-            className="p-4 block"
-            type="button"
-            onClick={() => {
-              toggleUserMenu(false);
-              toggleNews(!isNewsOpen);
-            }}
-            styled={false}
-          >
-            What's new?
-          </Button>
-        }
-        placement="right"
-        arrow
-        classes={{
-          tooltip: "bg-blue-50 custom-tooltip text-sm",
-          arrow: "text-blue-50",
-        }}
-      >
-        <div className="text-center">
-          <Button
-            styled={false}
-            className="p-2 md:p-4"
-            type="button"
-            onClick={() => {
-              toggleUserMenu(false);
-              toggleNews(!isNewsOpen);
+      <>
+        <OutsideClick
+          handler={e => {
+            toggleNews(false);
+          }}
+        >
+          <Tooltip
+            title={
+              <Button
+                className="p-4 block"
+                type="button"
+                onClick={() => {
+                  toggleUserMenu(false);
+                  toggleNews(!isNewsOpen);
+                }}
+                styled={false}
+              >
+                What's new?
+              </Button>
+            }
+            placement="right"
+            arrow
+            classes={{
+              tooltip: "bg-blue-50 custom-tooltip text-sm",
+              arrow: "text-blue-50",
             }}
           >
-            <span className="fas fa-bell text-base" />
-          </Button>
-        </div>
-      </Tooltip>
-      <Tooltip
-        title={
-          <UserMenu className="p-4" onClick={() => toggleUserMenu(false)} />
-        }
-        placement="right-end"
-        open={isUserMenuOpen}
-        classes={{
-          tooltip: "bg-blue-50 custom-tooltip text-sm",
-          arrow: "text-blue-50",
-        }}
-        arrow
-      >
-        <span className="flex items-center w-full">
-          <Button
-            className="hidden md:flex p-2 md:p-4 w-full"
-            styled={false}
-            type="button"
-            onClick={() => {
-              toggleUserMenu(!isUserMenuOpen);
-              toggleNews(false);
-            }}
-          >
-            <img
-              src={user.avatar}
-              alt={`${user.fullName || user.displayName} profile`}
-              className="rounded-full w-7 h-7 inline-block max-w-none"
-            />
-          </Button>
-        </span>
-      </Tooltip>
+            <div className="text-center">
+              <Button
+                styled={false}
+                className="p-2 md:p-4"
+                type="button"
+                onClick={() => {
+                  toggleUserMenu(false);
+                  toggleNews(!isNewsOpen);
+                }}
+              >
+                <span className="fas fa-bell text-base" />
+              </Button>
+            </div>
+          </Tooltip>
+        </OutsideClick>
+      </>
+
+      <>
+        <Tooltip
+          title={
+            <OutsideClick
+              handler={e => {
+                toggleUserMenu(false);
+              }}
+            >
+              <UserMenu className="p-4" onClick={() => toggleUserMenu(false)} />
+            </OutsideClick>
+          }
+          placement="right-end"
+          open={isUserMenuOpen}
+          classes={{
+            tooltip: "bg-blue-50 custom-tooltip text-sm",
+            arrow: "text-blue-50",
+          }}
+          arrow
+        >
+          <span className="flex items-center w-full">
+            <Button
+              className="hidden md:flex p-2 md:p-4 w-full"
+              styled={false}
+              type="button"
+              onClick={() => {
+                toggleUserMenu(!isUserMenuOpen);
+                toggleNews(false);
+              }}
+            >
+              <img
+                src={user.avatar}
+                alt={`${user.fullName || user.displayName} profile`}
+                className="rounded-full w-7 h-7 inline-block max-w-none"
+              />
+            </Button>
+          </span>
+        </Tooltip>
+      </>
+
       <SideBar isOpen={isNewsOpen} maxWidth="max-w-128">
         {isNewsOpen && (
           <iframe


### PR DESCRIPTION
Allow user and "what's news" modules to close when clicking outside of the buttons instead of expecting user to click on same button. 