### PR TITLE
chore: fix canary redirection

### DIFF
--- a/src/utils/api/Api.ts
+++ b/src/utils/api/Api.ts
@@ -110,6 +110,7 @@ class Api {
     }
 
     if (
+      localStorage.getItem("sk_canary") == 'true' ||
       document?.cookie.indexOf("sk_canary=true") > -1 ||
       window.location.search?.indexOf("sk_canary=true") > -1
     ) {


### PR DESCRIPTION
we use local storage to redirect request to canary but logic doing requests wasn't using canary instance. This fixes that