### PR TITLE
chore: fix modal logic for verification message

### DIFF
--- a/src/pages/apps/[id]/environments/[env-id]/config/_components/TabDomainConfig/DomainVerifyModal.tsx
+++ b/src/pages/apps/[id]/environments/[env-id]/config/_components/TabDomainConfig/DomainVerifyModal.tsx
@@ -46,7 +46,7 @@ const DomainVerificationStatus: React.FC<Props> = ({
         error={error}
         contentPadding={false}
         info={
-          refreshToken > 0
+          refreshToken > 0 && !info?.dns.verified
             ? "Domain is still not yet verified. If you updated your TXT record, please give it a bit time to propagate."
             : ""
         }


### PR DESCRIPTION
We still show warning after domain verification is completed. This pr fixes that