### PR TITLE
chore: rename property

### DIFF
--- a/src/layouts/AppLayout/_components/DeployModal.spec.tsx
+++ b/src/layouts/AppLayout/_components/DeployModal.spec.tsx
@@ -50,7 +50,7 @@ describe("~/layouts/AppLayout/_components/DeployModal.tsx", () => {
     currentApp = mockApp();
     currentEnv = mockEnv({ app: currentApp });
     currentEnv.branch = "";
-    currentEnv.build.cmd = "";
+    currentEnv.build.buildCmd = "";
     currentEnv.build.distFolder = "";
 
     const fetchMetaScope = mockFetchRepoMeta({
@@ -73,13 +73,13 @@ describe("~/layouts/AppLayout/_components/DeployModal.tsx", () => {
     distFolder: "my-dist",
     branch: "master",
     publish: true,
-    cmd: "echo hi",
+    buildCmd: "echo hi",
   };
 
   const executeDeployFlow = async () => {
     await userEvent.type(
       wrapper.getByLabelText("Build command"),
-      deployConfig.cmd
+      deployConfig.buildCmd
     );
 
     await userEvent.type(

--- a/src/layouts/AppLayout/_components/DeployModal.tsx
+++ b/src/layouts/AppLayout/_components/DeployModal.tsx
@@ -30,7 +30,7 @@ const DeployModal: React.FC<Props> = ({
     environment
   );
   const fetchResult = useFetchRepoMeta({ app, env: selectedEnv });
-  const [cmd, setCmd] = useState(environment?.build?.cmd || "");
+  const [cmd, setCmd] = useState(environment?.build?.buildCmd || "");
   const [dist, setDist] = useState(environment?.build?.distFolder || "");
   const [branch, setBranch] = useState(environment?.branch || "");
   const [error, setError] = useState<null | string>(null);
@@ -67,7 +67,7 @@ const DeployModal: React.FC<Props> = ({
               setLoading,
               config: {
                 branch,
-                cmd,
+                buildCmd: cmd,
                 distFolder: dist,
                 publish: isAutoPublish || false,
               },
@@ -89,7 +89,7 @@ const DeployModal: React.FC<Props> = ({
               onSelect={(env: Environment): void => {
                 if (env) {
                   setBranch(env.branch);
-                  setCmd(env.build.cmd);
+                  setCmd(env.build.buildCmd || "");
                   setDist(env.build.distFolder);
                   setIsAutoPublish(env.autoPublish);
                   setError(null);
@@ -123,7 +123,7 @@ const DeployModal: React.FC<Props> = ({
               <Form.Input
                 value={cmd}
                 fullWidth
-                name="build.cmd"
+                name="build.buildCmd"
                 onChange={e => setCmd(e.target.value)}
                 placeholder="Defaults to 'npm run build' or 'yarn build' or 'pnpm build'"
                 className="bg-blue-10 no-border h-full"

--- a/src/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigBuild.tsx
+++ b/src/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigBuild.tsx
@@ -76,9 +76,9 @@ export default function TabConfigGeneral({
           label="Build command"
           variant="filled"
           autoComplete="off"
-          defaultValue={env?.build.cmd || ""}
+          defaultValue={env?.build.buildCmd || ""}
           fullWidth
-          name="build.cmd"
+          name="build.buildCmd"
           placeholder="Defaults to 'npm run build' or 'yarn build' or 'pnpm build'"
           helperText={
             <>

--- a/src/pages/apps/[id]/environments/[env-id]/config/actions.spec.ts
+++ b/src/pages/apps/[id]/environments/[env-id]/config/actions.spec.ts
@@ -21,7 +21,7 @@ describe("~/pages/apps/[id]/environments/[env-id]/config/actions.tsx", () => {
         "build.redirectsFile": env.build.redirectsFile,
         "build.apiFolder": env.build.apiFolder,
         "build.apiPathPrefix": env.build.apiPathPrefix,
-        "build.cmd": env.build.cmd,
+        "build.buildCmd": env.build.buildCmd,
         "build.distFolder": env.build.distFolder,
         "build.vars": "BABEL_ENV=production\nNODE_ENV=production",
       });
@@ -68,7 +68,7 @@ describe("~/pages/apps/[id]/environments/[env-id]/config/actions.tsx", () => {
         "build.redirectsFile": env.build.redirectsFile,
         "build.apiFolder": env.build.apiFolder,
         "build.apiPathPrefix": env.build.apiPathPrefix,
-        "build.cmd": env.build.cmd,
+        "build.buildCmd": env.build.buildCmd,
         "build.distFolder": env.build.distFolder,
         "build.vars": "BABEL_ENV=production\nNODE_ENV=production",
       });

--- a/src/pages/apps/[id]/environments/[env-id]/config/actions.ts
+++ b/src/pages/apps/[id]/environments/[env-id]/config/actions.ts
@@ -40,7 +40,7 @@ export const prepareBuildObject = (values: FormValues): BuildConfig => {
     values["build.prerender.waitFor"];
 
   const build: BuildConfig = {
-    cmd: values["build.cmd"]?.trim() || "",
+    buildCmd: values["build.buildCmd"]?.trim() || "",
     distFolder: (values["build.distFolder"] || "").trim(),
     headersFile: values["build.headersFile"],
     redirectsFile: values["build.redirectsFile"],
@@ -102,7 +102,7 @@ export const buildFormValues = (
     "build.redirectsFile": env.build.redirectsFile,
     "build.apiFolder": env.build.apiFolder,
     "build.apiPathPrefix": env.build.apiPathPrefix,
-    "build.cmd": env.build.cmd,
+    "build.buildCmd": env.build.buildCmd,
     "build.distFolder": env.build.distFolder,
     "build.redirects": JSON.stringify(env.build.redirects),
     "build.vars": Object.keys(env.build?.vars || {})
@@ -187,7 +187,8 @@ export interface FormValues {
   autoPublish?: "on" | "off";
   autoDeployBranches?: string;
   "build.previewLinks"?: "on" | "off";
-  "build.cmd"?: string;
+  "build.buildCmd"?: string;
+  "build.serverCmd"?: string;
   "build.distFolder"?: string;
   "build.headersFile"?: string;
   "build.redirects"?: string;

--- a/src/pages/apps/[id]/environments/helpers.ts
+++ b/src/pages/apps/[id]/environments/helpers.ts
@@ -15,7 +15,7 @@ export const prepareBuildObject = (
   });
 
   const build: BuildConfig = {
-    cmd: values["build.cmd"],
+    buildCmd: values["build.buildCmd"],
     distFolder: values["build.distFolder"] || "",
     vars,
   };

--- a/src/pages/apps/actions.ts
+++ b/src/pages/apps/actions.ts
@@ -170,7 +170,7 @@ export const useFetchApp = ({ appId }: FetchAppProps): FetchAppReturnValue => {
 interface DeployProps {
   app: App;
   config?: {
-    cmd: string;
+    buildCmd: string;
     branch: string;
     distFolder?: string;
     publish: boolean;

--- a/src/types/environment.d.ts
+++ b/src/types/environment.d.ts
@@ -7,7 +7,8 @@ declare type BuildConfig = {
   redirectsFile?: string;
   redirects?: Redirect[];
   distFolder: string;
-  cmd: string;
+  buildCmd?: string;
+  serverCmd?: string;
   vars: Record<string, string>;
 };
 

--- a/testing/nocks/nock_deployments.ts
+++ b/testing/nocks/nock_deployments.ts
@@ -114,7 +114,7 @@ interface mockDeployNowProps {
   appId: string;
   config: {
     env: string;
-    cmd: string;
+    buildCmd: string;
     branch: string;
     distFolder: string;
     publish: boolean;

--- a/testing/nocks/nock_environment.ts
+++ b/testing/nocks/nock_environment.ts
@@ -20,7 +20,7 @@ const toRequestObject = (environment: Environment) => {
         redirectsFile: environment.build.redirectsFile,
         redirects: environment.build.redirects,
         distFolder: environment.build.distFolder,
-        cmd: environment.build.cmd,
+        buildCmd: environment.build.buildCmd || "",
         vars: environment.build.vars,
       },
     })


### PR DESCRIPTION
We are introducing a new serverCmd variable, so renaming cmd to buildCmd will make things clearer.